### PR TITLE
Use all BaseVersion* for versioning

### DIFF
--- a/src/Version.targets
+++ b/src/Version.targets
@@ -38,7 +38,7 @@
     <PropertyGroup>
       <VersionMetadataLabel>@(VersionMetadata -> '%(Identity)', '-')</VersionMetadataLabel>
       <VersionMetadataPlusLabel Condition="'$(VersionMetadataLabel)' != ''">+$(VersionMetadataLabel)</VersionMetadataPlusLabel>
-      <PackageVersion>$(GitSemVerMajor).$(GitSemVerMinor).$(GitBaseVersionPatch)$(GitSemVerDashLabel)</PackageVersion>
+      <PackageVersion>$(GitBaseVersionMajor).$(GitBaseVersionMinor).$(GitBaseVersionPatch)$(GitSemVerDashLabel)</PackageVersion>
       <Version>$(PackageVersion)$(VersionMetadataPlusLabel)</Version>
     </PropertyGroup>
 


### PR DESCRIPTION
Since the `$(GitBaseVersionPatch)` was being used, switch major and minor to base version too