### PR TITLE
Do not quote arguments with backslash separator

### DIFF
--- a/src/Xamarin.ProcessControl/ProcessArguments.cs
+++ b/src/Xamarin.ProcessControl/ProcessArguments.cs
@@ -144,7 +144,7 @@ namespace Xamarin.ProcessControl
 
             for (int i = 0; i < argument.Length; i++) {
                 var c = argument [i];
-                if (Char.IsWhiteSpace (c) || c == '\b' || c == '"' || c == '\\') {
+                if (Char.IsWhiteSpace (c) || c == '\b' || c == '"') {
                     if (builder == null) {
                         builder = new StringBuilder (argument.Length + 8);
                         builder.Append ('"');


### PR DESCRIPTION
This particular behavior breaks invoking 7zip with provisionator, because the output path 
parameter is specified as `-o[PATH]`. If the `PATH` has no spaces, no quoting is necessary 
around `-o` and it just works. However, with the current behavior, specifying `"-o[PATH]"` 
fails with 7zip not able to find the path.

Since we're not quoting `/` either, I wonder what's the rationale for quoting when `\` is 
present? Granted, that format for 7zip CLI is weird (all parameter values to right after the 
switch, with no space), and if quoting is needed, the quote is supposed to go around the 
switch value, but exclude the switch itself, but at least one could work around that by 
ensuring there are no whitespaces in the `-o` parameter, if it weren't for this existing quoting
behavior.