### PR TITLE
Update from macOS 10.13 to 10.14

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -15,7 +15,7 @@ pr:
 jobs:
 - job: macOS
   pool:
-    vmImage: 'macOS-10.13'
+    vmImage: 'macOS-10.14'
   steps:
   - template: .vsts-ci-steps.yml
 


### PR DESCRIPTION
macOS 10.13 will no longer be offered on the hosted pool as of March 23, 2020

see https://devblogs.microsoft.com/devops/removing-older-images-in-azure-pipelines-hosted-pools/