### PR TITLE
Build: .NET 6 SDK, drop ilrepack from build, change some target frameworks

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "2.1.505"
+    "version": "6.0.300"
   },
   "msbuild-sdks": {
     "Microsoft.Build.Traversal": "1.0.45"

--- a/mirepoix.proj
+++ b/mirepoix.proj
@@ -33,9 +33,9 @@
 
     <ProjectReference Include="src\Xamarin.Mac.Sdk\Xamarin.Mac.Sdk.csproj"/>
 
-    <ProjectReference Include="tools\ILRepackPatcher\ILRepackPatcher.csproj"/>
+    <!-- <ProjectReference Include="tools\ILRepackPatcher\ILRepackPatcher.csproj"/>
     <ProjectReference Include="src\Xamarin.BuildConsolidator\Xamarin.BuildConsolidator.csproj"/>
-    <ProjectReference Include="src\Xamarin.BuildConsolidator.Tests\Xamarin.BuildConsolidator.Tests.csproj"/>
+    <ProjectReference Include="src\Xamarin.BuildConsolidator.Tests\Xamarin.BuildConsolidator.Tests.csproj"/> -->
 
     <ProjectReference Include="src\Xamarin.Cecil.Rocks\Xamarin.Cecil.Rocks.csproj"/>
     <ProjectReference Include="src\Xamarin.Cecil.Rocks.Tests\Xamarin.Cecil.Rocks.Tests.csproj"/>

--- a/mirepoix.sln
+++ b/mirepoix.sln
@@ -35,12 +35,6 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Xamarin.MSBuild.Sdk.Tests",
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Xamarin.Mac.Sdk", "src\Xamarin.Mac.Sdk\Xamarin.Mac.Sdk.csproj", "{0A774290-7199-5364-BC2E-82526B386C7A}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ILRepackPatcher", "tools\ILRepackPatcher\ILRepackPatcher.csproj", "{F95EC498-1C9C-5C97-BE3B-0F6702E57314}"
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Xamarin.BuildConsolidator", "src\Xamarin.BuildConsolidator\Xamarin.BuildConsolidator.csproj", "{00109FC2-4F86-583E-93A8-167E47928E84}"
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Xamarin.BuildConsolidator.Tests", "src\Xamarin.BuildConsolidator.Tests\Xamarin.BuildConsolidator.Tests.csproj", "{CFC355DB-EB92-56D7-A0EE-4CF585D2A341}"
-EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Xamarin.Cecil.Rocks", "src\Xamarin.Cecil.Rocks\Xamarin.Cecil.Rocks.csproj", "{02CC9070-D5F4-571C-90F9-75B7E8F8D341}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Xamarin.Cecil.Rocks.Tests", "src\Xamarin.Cecil.Rocks.Tests\Xamarin.Cecil.Rocks.Tests.csproj", "{1D45883F-3DA7-5EA7-AE55-0F2634BE1C1A}"
@@ -120,18 +114,6 @@ Global
 		{0A774290-7199-5364-BC2E-82526B386C7A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{0A774290-7199-5364-BC2E-82526B386C7A}.Release|Any CPU.ActiveCfg = Debug|Any CPU
 		{0A774290-7199-5364-BC2E-82526B386C7A}.Release|Any CPU.Build.0 = Debug|Any CPU
-		{F95EC498-1C9C-5C97-BE3B-0F6702E57314}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{F95EC498-1C9C-5C97-BE3B-0F6702E57314}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{F95EC498-1C9C-5C97-BE3B-0F6702E57314}.Release|Any CPU.ActiveCfg = Debug|Any CPU
-		{F95EC498-1C9C-5C97-BE3B-0F6702E57314}.Release|Any CPU.Build.0 = Debug|Any CPU
-		{00109FC2-4F86-583E-93A8-167E47928E84}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{00109FC2-4F86-583E-93A8-167E47928E84}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{00109FC2-4F86-583E-93A8-167E47928E84}.Release|Any CPU.ActiveCfg = Debug|Any CPU
-		{00109FC2-4F86-583E-93A8-167E47928E84}.Release|Any CPU.Build.0 = Debug|Any CPU
-		{CFC355DB-EB92-56D7-A0EE-4CF585D2A341}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{CFC355DB-EB92-56D7-A0EE-4CF585D2A341}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{CFC355DB-EB92-56D7-A0EE-4CF585D2A341}.Release|Any CPU.ActiveCfg = Debug|Any CPU
-		{CFC355DB-EB92-56D7-A0EE-4CF585D2A341}.Release|Any CPU.Build.0 = Debug|Any CPU
 		{02CC9070-D5F4-571C-90F9-75B7E8F8D341}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{02CC9070-D5F4-571C-90F9-75B7E8F8D341}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{02CC9070-D5F4-571C-90F9-75B7E8F8D341}.Release|Any CPU.ActiveCfg = Debug|Any CPU

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -6,6 +6,7 @@
     <LangVersion>latest</LangVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <NoWarn>$(NoWarn);CA1416</NoWarn>
     <TargetLatestRuntimePatch>true</TargetLatestRuntimePatch>
   </PropertyGroup>
 
@@ -15,7 +16,9 @@
     <RepositoryUrl>https://github.com/xamarin/mirepoix</RepositoryUrl>
     <PackageProjectUrl>https://xamarin.github.io/mirepoix</PackageProjectUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <PackageIconUrl>https://www.xamarin.com/content/images/nuget/xamarin.png</PackageIconUrl>
+    <!-- This URL 404s, and PackageIconUrl is deprecated.
+         TODO: Embed an icon in the nupkg with PackageIcon -->
+    <!-- <PackageIconUrl>https://www.xamarin.com/content/images/nuget/xamarin.png</PackageIconUrl> -->
     <PackageOutputPath>$([MSBuild]::NormalizePath($(MSBuildThisFileDirectory)..\_artifacts\))</PackageOutputPath>
     <IncludeSymbols>true</IncludeSymbols>
   </PropertyGroup>
@@ -26,9 +29,9 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="$(IsTestProject)">
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
-    <NoWarn>xUnit1026</NoWarn>
+    <NoWarn>$(NoWarn);xUnit1026</NoWarn>
   </PropertyGroup>
 
   <ItemGroup Condition="$(IsTestProject)">

--- a/src/Xamarin.MSBuild.Sdk.Tests/DependencyGraphTests.cs
+++ b/src/Xamarin.MSBuild.Sdk.Tests/DependencyGraphTests.cs
@@ -50,9 +50,9 @@ namespace Xamarin.MSBuild.Sdk.Tests
                 p => Assert.Equal ("Xamarin.MSBuild.Sdk", p),
                 p => Assert.Equal ("Xamarin.MSBuild.Sdk.Tests", p),
                 p => Assert.Equal ("Xamarin.Mac.Sdk", p),
-                p => Assert.Equal ("ILRepackPatcher", p),
-                p => Assert.Equal ("Xamarin.BuildConsolidator", p),
-                p => Assert.Equal ("Xamarin.BuildConsolidator.Tests", p),
+                // p => Assert.Equal ("ILRepackPatcher", p),
+                // p => Assert.Equal ("Xamarin.BuildConsolidator", p),
+                // p => Assert.Equal ("Xamarin.BuildConsolidator.Tests", p),
                 p => Assert.Equal ("Xamarin.Cecil.Rocks", p),
                 p => Assert.Equal ("Xamarin.Cecil.Rocks.Tests", p),
                 p => Assert.Equal ("Xamarin.PropertyListDeserializer", p));

--- a/src/Xamarin.MSBuild.Sdk/Sdk.props
+++ b/src/Xamarin.MSBuild.Sdk/Sdk.props
@@ -1,9 +1,12 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <XamarinMSBuildSdkNuGetTaskAssembly>$(MSBuildThisFileDirectory)..\lib\netstandard2.0\Xamarin.MSBuild.Sdk.dll</XamarinMSBuildSdkNuGetTaskAssembly>
+    <_FrameworkFolderName>net472</_FrameworkFolderName>
+    <_FrameworkFolderName Condition="'$(MSBuildRuntimeType)' == 'Core'">net6.0</_FrameworkFolderName>
+
+    <XamarinMSBuildSdkNuGetTaskAssembly>$(MSBuildThisFileDirectory)..\lib\$(_FrameworkFolderName)\Xamarin.MSBuild.Sdk.dll</XamarinMSBuildSdkNuGetTaskAssembly>
     <XamarinMSBuildSdkAssembly Condition="Exists('$(XamarinMSBuildSdkNuGetTaskAssembly)')">$(XamarinMSBuildSdkNuGetTaskAssembly)</XamarinMSBuildSdkAssembly>
 
-    <XamarinMSBuildSdkLocalBuildTaskAssembly>$(MSBuildThisFileDirectory)\bin\Debug\netstandard2.0\Xamarin.MSBuild.Sdk.dll</XamarinMSBuildSdkLocalBuildTaskAssembly>
+    <XamarinMSBuildSdkLocalBuildTaskAssembly>$(MSBuildThisFileDirectory)bin\Debug\$(_FrameworkFolderName)\Xamarin.MSBuild.Sdk.dll</XamarinMSBuildSdkLocalBuildTaskAssembly>
     <XamarinMSBuildSdkAssembly Condition="Exists('$(XamarinMSBuildSdkLocalBuildTaskAssembly)')">$(XamarinMSBuildSdkLocalBuildTaskAssembly)</XamarinMSBuildSdkAssembly>
   </PropertyGroup>
 </Project>

--- a/src/Xamarin.MSBuild.Sdk/Xamarin.MSBuild.Sdk.csproj
+++ b/src/Xamarin.MSBuild.Sdk/Xamarin.MSBuild.Sdk.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>net6.0;net472</TargetFrameworks>
     <NoPackageAnalysis>true</NoPackageAnalysis>
     <PackageTypes>Dependency;MSBuildSdk</PackageTypes>
     <DevelopmentDependency>true</DevelopmentDependency>
@@ -13,11 +13,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Build" Version="15.8.166"/>
-    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="15.8.166"/>
+    <PackageReference Include="Microsoft.Build" Version="17.2.0"/>
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.2.0"/>
     <PackageReference Include="Microsoft.Win32.Registry" Version="4.5.0"/>
-    <PackageReference Include="System.Collections.Immutable" Version="1.5.0"/>
-    <PackageReference Include="System.Threading.Tasks.Dataflow" Version="4.9.0"/>
+    <PackageReference Include="System.Collections.Immutable" Version="6.0.0"/>
+    <PackageReference Include="System.Threading.Tasks.Dataflow" Version="6.0.0"/>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
.NET Core 2.1 is not supported on arm64 Macs. .NET 6.0.300 SDK is a
long-term support release with broad compatibility.

Newer `Microsoft.Build` package versions no longer have `netstandard2.0`
support (see https://github.com/dotnet/msbuild/issues/4521). Update
`Xamarin.MSBuild.Sdk` to multi-target `net6.0` and `net472` to address
this.

`Xamarin.BuildConsolidator` depends on ILRepack, which is not supported
in .NET 6. The only actively-used consolidation support comes from
`PrepareConsolidationProject` in `Xamarin.MSBuild.Sdk`, so remove the
unused projects from the build.